### PR TITLE
feature: Create some helper functions to simplify creating migrations

### DIFF
--- a/migration-core/src/test/kotlin/com/boswelja/migration/MigrationTestHelpers.kt
+++ b/migration-core/src/test/kotlin/com/boswelja/migration/MigrationTestHelpers.kt
@@ -1,30 +1,11 @@
 package com.boswelja.migration
 
-import io.mockk.spyk
-
-class ConcreteVersionMigration(
-    fromVersion: Int,
-    toVersion: Int,
-    private val migrateResult: (fromVersion: Int) -> Boolean
-) : VersionMigration(fromVersion, toVersion) {
-    override suspend fun migrate(): Boolean = migrateResult(fromVersion)
-}
-
-class ConcreteConstatntMigration(
-    private val shouldMigrateResult: (fromVersion: Int) -> Boolean,
-    private val migrateResult: () -> Boolean
-) : Migration {
-    override val toVersion: Int? = null
-    override suspend fun shouldMigrate(fromVersion: Int): Boolean = shouldMigrateResult(fromVersion)
-    override suspend fun migrate(): Boolean = migrateResult()
-}
-
 fun createVersionedMigrations(
     fromVersion: Int,
     toVersion: Int,
     migrateResult: (fromVersion: Int) -> Boolean
 ) = (fromVersion..toVersion).map { fromVer ->
-    spyk(ConcreteVersionMigration(fromVer, fromVer + 1, migrateResult))
+    versionMigration(fromVer, fromVer + 1) { migrateResult(fromVer) }
 }
 
 fun createConstantMigrations(
@@ -32,10 +13,8 @@ fun createConstantMigrations(
     shouldMigrate: (index: Int) -> Boolean,
     migrateResult: (index: Int) -> Boolean
 ) = (0 until count).map { index ->
-    spyk(
-        ConcreteConstatntMigration(
-            shouldMigrate,
-            { migrateResult(index) }
-        )
+    conditionalMigration(
+        onShouldMigrate = { shouldMigrate(index) },
+        onMigrate = { migrateResult(index) }
     )
 }

--- a/migration-core/src/test/kotlin/com/boswelja/migration/VersionMigrationTest.kt
+++ b/migration-core/src/test/kotlin/com/boswelja/migration/VersionMigrationTest.kt
@@ -12,9 +12,7 @@ class VersionMigrationTest {
     fun `shouldMigrate returns true if the migration can be applied`() {
         val fromVersion = 1
         val toVersion = 2
-        val migration = object : VersionMigration(fromVersion, toVersion) {
-            override suspend fun migrate(): Boolean = true
-        }
+        val migration = versionMigration(fromVersion, toVersion) { true }
 
         val shouldMigrate = runBlocking { migration.shouldMigrate(fromVersion) }
         expectThat(shouldMigrate).isTrue()
@@ -24,9 +22,7 @@ class VersionMigrationTest {
     fun `shouldMigrate returns false if the migration cannot be applied`() {
         val fromVersion = 1
         val toVersion = 2
-        val migration = object : VersionMigration(fromVersion, toVersion) {
-            override suspend fun migrate(): Boolean = true
-        }
+        val migration = versionMigration(fromVersion, toVersion) { true }
 
         val shouldMigrate = runBlocking { migration.shouldMigrate(toVersion) }
         expectThat(shouldMigrate).isFalse()


### PR DESCRIPTION
This should make it easier to create migrations. It's still possible to create custom classes / objects that extend migrations, in case you need a little more flexibility.